### PR TITLE
Fixes for Valheim 0.216.9

### DIFF
--- a/SkToolboxValheim/SkToolbox/SkCommandProcessor.cs
+++ b/SkToolboxValheim/SkToolbox/SkCommandProcessor.cs
@@ -1197,7 +1197,7 @@ namespace SkToolbox
                         {
                             try
                             {
-                                component.GetZDO().SetPGWVersion(ZNetObject[0].GetZDO().GetPGWVersion());
+                                //component.GetZDO().SetPGWVersion(ZNetObject[0].GetZDO().GetPGWVersion());
                                 ZNetObject[0].GetZDO().Set("spawn_id", component.GetZDO().m_uid);
                                 ZNetObject[0].GetZDO().Set("alive_time", ZNet.instance.GetTime().Ticks);
                             }
@@ -2624,7 +2624,7 @@ namespace SkToolbox
         {
             if (Chat.instance != null)
             {
-                Chat.instance.OnNewChatMessage(null, 999, chatPos, Talker.Type.Normal, source, ln);
+                Chat.instance.OnNewChatMessage(null, 999, chatPos, Talker.Type.Normal, UserInfo.GetLocalUser(), source, ln);
                 SkUtilities.SetPrivateField(Chat.instance, "m_hideTimer", 0f);
                 Chat.instance.m_chatWindow.gameObject.SetActive(true);
                 Chat.instance.m_input.gameObject.SetActive(true);
@@ -2682,7 +2682,7 @@ namespace SkToolbox
             {
                 float levelOffset = prefab.GetComponent<TerrainModifier>().m_levelOffset;
                 GameObject terrainObject = UnityEngine.Object.Instantiate(prefab, position - Vector3.up * levelOffset, Quaternion.identity);
-                terrainObject.GetComponent<ZNetView>().GetZDO().SetPGWVersion(component.GetZDO().GetPGWVersion());
+                //terrainObject.GetComponent<ZNetView>().GetZDO().SetPGWVersion(component.GetZDO().GetPGWVersion());
             }
 
             //Thank you to BlueAmulet for this code

--- a/SkToolboxValheim/SkToolbox/SkModules/ModConsole.cs
+++ b/SkToolboxValheim/SkToolbox/SkModules/ModConsole.cs
@@ -410,7 +410,7 @@ namespace SkToolbox.SkModules
                     ConsoleOutputStyle = new GUIStyle();
                     ConsoleOutputStyle.wordWrap = true;
 
-                    int fontSize = Console.instance.m_output.fontSize;
+                    int fontSize = (int)Console.instance.m_output.fontSize;
                     string font = "Consolas";
                     Color outputColor = Console.instance.m_output.color;
                     Color inputColor = Console.instance.m_input.textComponent.color;
@@ -438,7 +438,7 @@ namespace SkToolbox.SkModules
                     Console.instance.m_input.caretColor = caretColor;
                     Console.instance.m_input.customCaretColor = true;
 
-                    Console.instance.m_output.font = consoleFont;
+                    Console.instance.m_output.font = TMPro.TMP_FontAsset.CreateFontAsset(consoleFont);
                     Console.instance.m_output.fontSize = fontSize;
                     Console.instance.m_output.color = outputColor;
 

--- a/SkToolboxValheim/SkToolboxValheim.csproj
+++ b/SkToolboxValheim/SkToolboxValheim.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Xml">
       <Private>False</Private>
     </Reference>
+    <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL" />
     <Reference Include="UnityEngine">
       <HintPath>D:\Games\Steam\steamapps\common\Valheim\unstripped_corlib\UnityEngine.dll</HintPath>
       <Private>False</Private>


### PR DESCRIPTION
- Disables ZDO PGW versioning on `/spawn` and terrain commands as this was removed from Valheim entirely
- Added newly required `UserInfo` field to `ChatPrint` function
- Fixed code for new `Unity.TextMeshPro` requirement